### PR TITLE
Feature/45 endpoint recuperar challenges

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { CellModule } from './cell/cell.module';
 import { QuizModule } from './quiz/quiz.module';
 import { QuestionModule } from './question/question.module';
 import { UserModule } from './user/user.module';
+import { ChallengeModule } from './challenge/challenge.module';
 
 @Module({
   imports: [
@@ -22,7 +23,8 @@ import { UserModule } from './user/user.module';
     CellModule,
     QuizModule,
     QuestionModule,
-    UserModule
+    UserModule,
+    ChallengeModule
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/challenge/challenge.controller.spec.ts
+++ b/src/challenge/challenge.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChallengeController } from './challenge.controller';
+import { ChallengeService } from './challenge.service';
+
+describe('ChallengeController', () => {
+  let controller: ChallengeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChallengeController],
+      providers: [ChallengeService],
+    }).compile();
+
+    controller = module.get<ChallengeController>(ChallengeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+} from '@nestjs/common';
+import { ChallengeService } from './challenge.service';
+import { CreateChallengeDto } from './dto/create-challenge.dto';
+import { UpdateChallengeDto } from './dto/update-challenge.dto';
+import { FindChallengesFiltersDto } from './dto/find-challenges-filters.dto';
+import { ApiNotFoundResponse, ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Challenge')
+@Controller('challenge')
+export class ChallengeController {
+  constructor(private readonly challengeService: ChallengeService) {}
+
+
+  @Post()
+  create(@Body() createChallengeDto: CreateChallengeDto) {
+    return this.challengeService.create(createChallengeDto);
+  }
+
+  @Get()
+  @ApiOkResponse({ description: 'Lista de  challenges devuelta exitosamente.' })
+  @ApiNotFoundResponse({ description: 'Ningún challenge encontrado.' })
+  @ApiQuery({ name: 'search', required: false, description: 'Search term for user details' })
+  @ApiQuery({ name: 'cell', required: false, description: 'Filtrar nombre de célula' })
+  @ApiQuery({ name: 'seniority', required: false, description: 'Filtrar por seniority del quiz' })
+  @ApiQuery({ name: 'module', required: false, description: 'Filtrar por nombre de módulo' })
+  async findAll(@Query() filters: FindChallengesFiltersDto) {
+    const { challenges, total } =
+      await this.challengeService.findChallenges(filters);
+    return { data: challenges, total };
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.challengeService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateChallengeDto: UpdateChallengeDto,
+  ) {
+    return this.challengeService.update(+id, updateChallengeDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.challengeService.remove(+id);
+  }
+}

--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -28,7 +28,7 @@ export class ChallengeController {
   @Get()
   @ApiOkResponse({ description: 'Lista de  challenges devuelta exitosamente.' })
   @ApiNotFoundResponse({ description: 'Ningún challenge encontrado.' })
-  @ApiQuery({ name: 'search', required: false, description: 'Search term for user details' })
+  @ApiQuery({ name: 'search', required: false, description: 'Filtra por first_name o last_name del usuario' })
   @ApiQuery({ name: 'cell', required: false, description: 'Filtrar nombre de célula' })
   @ApiQuery({ name: 'seniority', required: false, description: 'Filtrar por seniority del quiz' })
   @ApiQuery({ name: 'module', required: false, description: 'Filtrar por nombre de módulo' })
@@ -40,7 +40,7 @@ export class ChallengeController {
 
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.challengeService.findOne(+id);
+    return this.challengeService.findOne(id);
   }
 
   @Patch(':id')
@@ -48,11 +48,11 @@ export class ChallengeController {
     @Param('id') id: string,
     @Body() updateChallengeDto: UpdateChallengeDto,
   ) {
-    return this.challengeService.update(+id, updateChallengeDto);
+    return this.challengeService.update(id, updateChallengeDto);
   }
 
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.challengeService.remove(+id);
+    return this.challengeService.remove(id);
   }
 }

--- a/src/challenge/challenge.module.ts
+++ b/src/challenge/challenge.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ChallengeService } from './challenge.service';
+import { ChallengeController } from './challenge.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [ChallengeController],
+  providers: [ChallengeService],
+  imports: [PrismaModule]
+})
+export class ChallengeModule {}

--- a/src/challenge/challenge.service.spec.ts
+++ b/src/challenge/challenge.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChallengeService } from './challenge.service';
+
+describe('ChallengeService', () => {
+  let service: ChallengeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChallengeService],
+    }).compile();
+
+    service = module.get<ChallengeService>(ChallengeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -86,15 +86,15 @@ export class ChallengeService {
     return { challenges, total };
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} challenge`;
+  findOne(id: string) {
+    return this.prisma.challenge.findUnique({ where: { id } });
   }
 
-  update(id: number, updateChallengeDto: UpdateChallengeDto) {
-    return `This action updates a #${id} challenge`;
+  update(id: string, data: UpdateChallengeDto) {
+    return this.prisma.challenge.update({ where: { id }, data });
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} challenge`;
+  remove(id: string) {
+    return this.prisma.challenge.delete({ where: { id } });
   }
 }

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@nestjs/common';
+import { CreateChallengeDto } from './dto/create-challenge.dto';
+import { UpdateChallengeDto } from './dto/update-challenge.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Challenge, Prisma, Seniority } from '@prisma/client';
+
+@Injectable()
+export class ChallengeService {
+  constructor(private prisma: PrismaService) {}
+
+  //Crear challenge
+  async create(data: CreateChallengeDto) {
+    return await this.prisma.challenge.create({ data });
+  }
+
+  async findChallenges(filters: {
+    search?: string;
+    cell?: string;
+    seniority?: string;
+    module?: string;
+  }): Promise<{ challenges: Challenge[]; total: number }> {
+    const { search, cell, seniority, module } = filters;
+
+    // Se crea un objeto 'where' para los filtros de la consulta
+    let where: Prisma.ChallengeWhereInput = {};
+
+    // Si existe un término de búsqueda, se aplica a varios campos
+    if (search) {
+      where.OR = [
+        { user: { first_name: { contains: search, mode: 'insensitive' } } },
+        { user: { last_name: { contains: search, mode: 'insensitive' } } },
+        { user: { email: { contains: search, mode: 'insensitive' } } },
+      ];
+    }
+
+    // Filtro por seniority
+    if (seniority) {
+      where.quiz = {
+        seniority: seniority as Seniority,
+      };
+    }
+
+    // Filtro por módulo (a través de la relación quiz -> cell -> module)
+    if (module) {
+      where.quiz = {
+        cell: {
+          module: {
+            name: { equals: module, mode: 'insensitive' },
+          },
+        },
+      };
+    }
+
+    // Filtro por célula (a través de la relación quiz -> cell)
+    if (cell) {
+      where.quiz = {
+        cell: {
+          name: { equals: cell, mode: 'insensitive' },
+        },
+      };
+    }
+
+    // Se ejecutan las dos consultas en paralelo para mejorar el rendimiento
+    const [challenges, total] = await Promise.all([
+      this.prisma.challenge.findMany({
+        where,
+        include: {
+          user: true,
+          quiz: {
+            include: {
+              cell: {
+                include: {
+                  module: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          created_at: 'desc',
+        },
+      }),
+      this.prisma.challenge.count({ where }),
+    ]);
+
+    return { challenges, total };
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} challenge`;
+  }
+
+  update(id: number, updateChallengeDto: UpdateChallengeDto) {
+    return `This action updates a #${id} challenge`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} challenge`;
+  }
+}

--- a/src/challenge/dto/create-challenge.dto.ts
+++ b/src/challenge/dto/create-challenge.dto.ts
@@ -1,0 +1,17 @@
+import { IsNotEmpty, IsInt, IsString, IsUUID } from 'class-validator';
+
+export class CreateChallengeDto {
+  @IsInt()
+  @IsNotEmpty()
+  calification: number;
+
+  @IsString()
+  @IsUUID()
+  @IsNotEmpty()
+  quiz_id: string;
+
+  @IsString()
+  @IsUUID()
+  @IsNotEmpty()
+  user_id: string;
+}

--- a/src/challenge/dto/find-challenges-filters.dto.ts
+++ b/src/challenge/dto/find-challenges-filters.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString, IsEnum } from 'class-validator';
+import { Seniority } from '@prisma/client'; // Asegúrate de importar tu tipo Seniority de Prisma
+
+export class FindChallengesFiltersDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsString()
+  module?: string;
+
+  @IsOptional()
+  @IsString()
+  cell?: string;
+
+  @IsOptional()
+  @IsEnum(Seniority)
+  seniority?: Seniority;
+}

--- a/src/challenge/dto/update-challenge.dto.ts
+++ b/src/challenge/dto/update-challenge.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateChallengeDto } from './create-challenge.dto';
+
+export class UpdateChallengeDto extends PartialType(CreateChallengeDto) {}

--- a/src/challenge/entities/challenge.entity.ts
+++ b/src/challenge/entities/challenge.entity.ts
@@ -1,0 +1,1 @@
+export class Challenge {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ async function bootstrap() {
     .addTag('Module')
     .addTag('Cell')
     .addTag('User')
+    .addTag('Challenge')
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document, {


### PR DESCRIPTION
Etiqueta #45 

No existía el módulo challenge, así que se creó. Incluyendo no sólo el método recuperar challenges. Se incluyeron:

- Crear challenge
- Recuperar challenge por id
- Recuperar todos los challenge, con filtros por senority, célula, módulo o nombre del usuario
- Actualizar challenge
- Eliminar challenge